### PR TITLE
Improve live page design

### DIFF
--- a/assets/js/live.js
+++ b/assets/js/live.js
@@ -1,4 +1,5 @@
 const common_comment = require('./comment_loader');
+const kit = require('./components/kanzakit');
 
 module.exports = {
   ready() {
@@ -12,7 +13,7 @@ module.exports = {
     setInterval(this.live.date, 1000);
 
     $('#toot').keydown(({ keyCode, ctrlKey, metaKey }) => {
-      if (keyCode === 13 && (ctrlKey || metaKey)) {
+      if (keyCode === 13) {
         knzk.live.comment.post();
       }
     });

--- a/assets/js/live.js
+++ b/assets/js/live.js
@@ -16,6 +16,7 @@ module.exports = {
         knzk.live.comment.post();
       }
     });
+    $('[data-toggle="popover"]').popover();
   },
   comment: require('./live/comment'),
   share: require('./live/share'),

--- a/assets/js/live.js
+++ b/assets/js/live.js
@@ -1,5 +1,4 @@
 const common_comment = require('./comment_loader');
-const kit = require('./components/kanzakit');
 
 module.exports = {
   ready() {

--- a/assets/js/live/comment.js
+++ b/assets/js/live/comment.js
@@ -24,7 +24,7 @@ class comment {
       (config.account.domain === 'twitter.com' ? 140 : 500) -
       config.live.hashtag.length -
       d.length;
-    toot.maxlength = result;
+    toot.maxLength = parseInt(result);
   }
 
   static toggleLocal() {

--- a/assets/js/live/comment.js
+++ b/assets/js/live/comment.js
@@ -15,7 +15,7 @@ class comment {
       (config.account.domain === 'twitter.com' ? 140 : 500) -
       config.live.hashtag.length -
       d.length;
-    kit.elemId('limit').innerText = result;
+    kit.elemId('toot').maxlength = result;
   }
 
   static post() {
@@ -34,7 +34,6 @@ class comment {
         .then(json => {
           if (json) {
             kit.elemId('toot').value = '';
-            comment.check_limit();
           }
         });
     } else {
@@ -59,7 +58,6 @@ class comment {
         .then(json => {
           if (json) {
             kit.elemId('toot').value = '';
-            comment.check_limit();
           }
         })
         .catch(error => {

--- a/assets/js/live/comment.js
+++ b/assets/js/live/comment.js
@@ -8,20 +8,42 @@ const toast = require('../components/toast');
 
 class comment {
   static check_limit() {
-    if (!config.account) return; //未ログイン
-    const d = kit.elemId('toot').value;
+    const toot = kit.elemId('toot');
+
+    if (!config.account) {
+      toot.value =
+        'コメントするにはログインするか、 #' +
+        config.live.hashtag_o +
+        ' でトゥートしてください。';
+      toot.disabled = true;
+      return;
+    }
+    const d = toot.value;
 
     const result =
       (config.account.domain === 'twitter.com' ? 140 : 500) -
       config.live.hashtag.length -
       d.length;
-    kit.elemId('toot').maxlength = result;
+    toot.maxlength = result;
+  }
+
+  static toggleLocal() {
+    const s = kit.elemId('no_toot');
+    const bt = kit.elemId('comment_local_button');
+    bt.classList.remove('btn-outline-primary', 'btn-primary');
+    if (s.value) {
+      s.value = '';
+      bt.classList.add('btn-outline-primary');
+    } else {
+      s.value = '1';
+      bt.classList.add('btn-primary');
+    }
   }
 
   static post() {
     const v = kit.elemId('toot').value;
     if (!v) return;
-    const isKnzk = kit.elemId('no_toot').checked;
+    const isKnzk = !!kit.elemId('no_toot').value;
 
     if (isKnzk || config.account.domain === 'twitter.com') {
       api

--- a/assets/js/live/live.js
+++ b/assets/js/live/live.js
@@ -10,7 +10,7 @@ class live {
         err.innerHTML = '';
 
         if (json['live_status'] === 1)
-          err.innerHTML = '配信者からデータが送信されていません。';
+          err.innerHTML = '配信者のプッシュを待っています...';
         if (json['live_status'] === 0) {
           err.innerHTML = 'この配信は終了しました。';
           live.widemode('hide');

--- a/assets/js/live/live.js
+++ b/assets/js/live/live.js
@@ -27,7 +27,7 @@ class live {
 
         kit.elemId('is_not_started').className = json['is_started']
           ? 'invisible'
-          : 'text-warning';
+          : 'bg-warning text-dark';
 
         if (json['name'] !== config.live.watch_data['name']) {
           kit.elemId('live-name').innerText = json['name'];

--- a/assets/js/live/live.js
+++ b/assets/js/live/live.js
@@ -27,7 +27,7 @@ class live {
 
         kit.elemId('is_not_started').className = json['is_started']
           ? 'invisible'
-          : 'bg-warning text-dark';
+          : 'text-warning';
 
         if (json['name'] !== config.live.watch_data['name']) {
           kit.elemId('live-name').innerText = json['name'];

--- a/assets/scss/page/live.scss
+++ b/assets/scss/page/live.scss
@@ -26,6 +26,11 @@ html[data-page='live'] {
 
   #live-name {
     font-weight: 600;
+    margin-top: 10px;
+  }
+
+  .live_edit {
+    margin: 10px 0;
   }
 
   .is_wide {
@@ -139,12 +144,6 @@ html[data-page='live'] {
     margin-right: 15px;
   }
 
-  .comment-limit {
-    width: calc(100% - 30px);
-    height: 0;
-    position: absolute;
-  }
-
   .comment-option {
     height: 38px;
   }
@@ -158,17 +157,6 @@ html[data-page='live'] {
     position: absolute;
     width: 90px;
     right: 15px;
-  }
-
-  #limit {
-    position: relative;
-    right: 8px;
-    bottom: 25px;
-    color: #495057;
-  }
-
-  p#limit {
-    margin-bottom: 0;
   }
 
   .comment_block .form-group {
@@ -189,5 +177,13 @@ html[data-page='live'] {
 
   #listener_list td {
     color: $black;
+  }
+
+  #toot {
+    border-radius: 0 0 0.25em 0.25em;
+  }
+
+  .alerts {
+    margin-top: 10px;
   }
 }

--- a/assets/scss/page/live.scss
+++ b/assets/scss/page/live.scss
@@ -180,10 +180,15 @@ html[data-page='live'] {
   }
 
   #toot {
-    border-radius: 0 0 0.25em 0.25em;
+    border-radius: 0 0 0 0.25em;
   }
 
   .alerts {
     margin-top: 10px;
+  }
+
+  .popover,
+  .popover-body {
+    color: #000 !important;
   }
 }

--- a/include/live/comment.php
+++ b/include/live/comment.php
@@ -11,29 +11,6 @@
       <hr>
     </div>
   <?php endif; ?>
-  <?php if ($my) : ?>
-  <div class="comment_block">
-    <div class="form-group">
-      <textarea class="form-control" id="toot" rows="3" placeholder="<?=$my["acct"]?>でトゥート/コメント" onkeyup="live.comment.check_limit()"></textarea>
-    </div>
-    <div class="comment-limit"><p id="limit" class="float-right"></p></div>
-    <div class="comment-option my-2">
-      <div class="custom-control custom-checkbox col">
-        <input type="checkbox" class="custom-control-input" id="no_toot" value="1" <?=($my["misc"]["no_toot_default"] ? "checked" : "")?>>
-        <label class="custom-control-label" for="no_toot">
-          <small>コメントのみ投稿 <a href="#" onclick="alert('有効にした状態で投稿すると、KnzkLiveにコメントしますが<?=$_SESSION["account_provider"]?>には投稿されません。');return false">？</a></small>
-        </label>
-      </div>
-      <button class="btn btn-primary col comment-btn" onclick="live.comment.post()">コメント</button>
-    </div>
-  </div>
-  <?php else : ?>
-    <p>
-    コメントを投稿するにはKnzkLiveにログインするか、 <b>#<?=liveTag($live)?></b> でトゥートしてください！<br>
-    <small class="text-warning">* Mastodonからのコメントは <?=$env["masto_login"]["domain"]?> のハッシュタグTLから読み込まれます。<?=$env["masto_login"]["domain"]?> にフォローされていて公開トゥートのみ表示できます。</small>
-    </p>
-    <hr>
-  <?php endif; ?>
   <div id="donators" class="mt-2" style="display: none"></div>
   <p class="invisible" id="err_comment">
     <span class="text-warning">

--- a/public/auth/twitter.php
+++ b/public/auth/twitter.php
@@ -35,6 +35,7 @@ if (empty($_GET["oauth_verifier"])) {
     $misc["avatar"] = $content["profile_image_url_https"];
     $misc["header"] = $content["profile_banner_url"];
     $misc["user_url"] = "https://twitter.com/" . s($content["screen_name"]);
+    $misc["no_toot_default"] = true;
     $misc = json_encode($misc);
 
     $stmt = $mysqli->prepare("INSERT INTO `users` (`name`, `acct`, `created_at`, `ip`, `misc`, `twitter_id`) VALUES (?, ?, CURRENT_TIMESTAMP, ?, ?, ?);");

--- a/public/live.php
+++ b/public/live.php
@@ -107,54 +107,31 @@ $vote = loadVote($live["id"]);
 <?php else : ?>
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-9">
-      <div id="err_live" class="text-warning"></div>
-      <div id="is_not_started" class="invisible">* この配信はまだ開始されていません。現在はあなたのみ視聴できます。<a href="<?=u("live_manage")?>">配信開始はこちらから</a></div>
-      <?php if ($my["id"] === $live["user_id"]) : ?>
-        <div class="text-warning">* これは自分の放送です。ハウリング防止の為自動でミュートしています。</div>
-      <?php endif; ?>
+    <div class="col-xl-9 col-lg-8">
       <div class="embed-responsive embed-responsive-16by9" id="live">
         <iframe class="embed-responsive-item" src="<?=u("live_embed")?>?id=<?=$id?>&rtmp=<?=$slot["server"]?>" allowfullscreen id="iframe" allow="autoplay; fullscreen"></iframe>
       </div>
-      <span class="float-right">
-        <span class="live-info" id="time"></span>
-        <span class="live-info"><i class="fas fa-hat-wizard"></i> <b class="point_count"><?=$live["point_count"]?></b>KP</span>
-        <span class="live-info"><i class="fas fa-comments"></i> <b id="comment_count"><?=s($live["comment_count"])?></b></span>
 
-        <span id="count_open">
-          <i class="fas fa-users"></i> <b class="count"><?=$live["viewers_count"]?></b> / <span class="max"><?=$live["viewers_max"]?></span>
-        </span>
-        <span id="count_end" class="invisible">
-          総視聴者数: <span class="max"><?=$live["viewers_max"]?></span>人    最大同時視聴者数: <span id="max_c"><?=$live["viewers_max_concurrent"]?></span>人
-        </span>
-      </span>
-      <br>
-      <div class="float-right">
-        <?php if ($live["is_live"] !== 0 && $my["id"] === $live["user_id"]) : ?>
-          <button type="button" class="btn btn-outline-warning live_edit invisible" onclick="live.admin.undoEditLive()"><i class="fas fa-times"></i> 編集廃棄</button>
-          <button type="button" class="btn btn-outline-success live_edit invisible" onclick="live.admin.editLive()" style="margin-right:10px"><i class="fas fa-check"></i> 編集完了</button>
-        <?php endif; ?>
-        <?php if (!empty($my) && $live["is_live"] !== 0) : ?>
-          <button type="button" class="btn btn-outline-success" data-toggle="modal" data-target="#itemModal"><i class="fas fa-hat-wizard"></i> アイテム</button>
-        <?php endif; ?>
-
-        <?php if (donation_url($liveUser["id"], false) && $live["is_live"] !== 0) : ?>
-          <button type="button" class="btn btn-outline-warning" data-toggle="modal" data-target="#chModal"><i class="fas fa-donate"></i> 支援 (CH)</button>
-        <?php elseif (donation_url($liveUser["id"])) : ?>
-          <a class="btn btn-outline-warning" href="<?=donation_url($liveUser["id"])?>" target="_blank"><i class="fas fa-donate"></i> 支援</a>
-        <?php endif; ?>
-
-        <button type="button" class="btn btn-link side-buttons" onclick="live.share.share()"><i class="fas fa-share-square"></i> 共有</button>
+      <div class="comment_block">
+        <div class="form-group">
+          <input class="form-control" id="toot" placeholder="Enterでコメント..." type="text">
+        </div>
       </div>
-      <p></p>
+
+      <div class="alerts">
+        <div id="err_live" class="bg-warning text-dark"></div>
+        <div id="is_not_started" class="invisible">* この配信はまだ開始されていません。現在はあなたのみ視聴できます。<a href="<?=u("live_manage")?>">配信開始はこちらから</a></div>
+      </div>
+
       <h4 id="live-name" class="live_info"><?=$live["name"]?></h4>
 
-      <div class="input-group col-md-6 invisible live_edit" style="margin-bottom:20px">
+      <div class="input-group col-md-6 invisible live_edit">
         <div class="input-group-prepend">
           <span class="input-group-text" id="edit_title_label">タイトル</span>
         </div>
         <input type="text" class="form-control" placeholder="タイトル (100文字以下)" value="<?=$live["name"]?>" id="edit_name">
       </div>
+
       <span class="text-secondary">
         <?php if ($live["is_live"] !== 0) : ?>
           <?=date("Y/m/d H:i", strtotime($live["created_at"]))?> に開始
@@ -162,6 +139,7 @@ $vote = loadVote($live["id"]);
           <?=date("Y/m/d H:i", strtotime($live["created_at"]))?> - <?=date("Y/m/d H:i", strtotime($live["ended_at"]))?>
         <?php endif; ?>
       </span>
+
       <p id="live-description" class="live_info"><?=HTMLHelper($live["description"])?></p>
 
       <div class="input-group col-md-8 invisible live_edit">
@@ -171,19 +149,51 @@ $vote = loadVote($live["id"]);
         <textarea class="form-control" id="edit_desc" rows="4"><?=$live["description"]?></textarea>
       </div>
 
+      <div class="live_edit invisible">
+        <button type="button" class="btn btn-outline-warning" onclick="live.admin.undoEditLive()"><i class="fas fa-times"></i> 編集廃棄</button>
+        <button type="button" class="btn btn-outline-success" onclick="live.admin.editLive()" style="margin-right:10px"><i class="fas fa-check"></i> 編集完了</button>
+      </div>
+
       <?php if ($live["is_live"] !== 0 && $my["id"] === $live["user_id"]) : ?>
-      <hr>
-      <?php include "../include/live/broadcaster_panel.php"; ?>
+        <hr>
+        <?php include "../include/live/broadcaster_panel.php"; ?>
       <?php endif; ?>
+
       <?php if (is_admin($my["id"])) : ?>
-      <hr>
-      <?php include "../include/live/admin_panel.php"; ?>
+        <hr>
+        <?php include "../include/live/admin_panel.php"; ?>
       <?php endif; ?>
+
       <p>
         <a href="<?=u("report")?>?liveid=<?=$live["id"]?>" target="_blank" class="text-danger">配信を通報する</a>
       </p>
     </div>
-    <div class="col-md-3" id="comment">
+    <div class="col-xl-3 col-lg-4" id="comment">
+      <div>
+        <span class="live-info" id="time"></span>
+        <span class="live-info"><i class="fas fa-hat-wizard"></i> <b class="point_count"><?=$live["point_count"]?></b>KP</span>
+        <span class="live-info"><i class="fas fa-comments"></i> <b id="comment_count"><?=s($live["comment_count"])?></b></span>
+        <span id="count_open">
+          <i class="fas fa-users"></i> <b class="count"><?=$live["viewers_count"]?></b> / <span class="max"><?=$live["viewers_max"]?></span>
+        </span>
+        <span id="count_end" class="invisible">
+          総視聴者数: <span class="max"><?=$live["viewers_max"]?></span>人    最大同時視聴者数: <span id="max_c"><?=$live["viewers_max_concurrent"]?></span>人
+        </span>
+      </div>
+
+      <div class="btn-group btn-block" role="group">
+        <?php if (!empty($my) && $live["is_live"] !== 0) : ?>
+          <button type="button" class="btn btn-outline-success" data-toggle="modal" data-target="#itemModal"><i class="fas fa-hat-wizard"></i> アイテム</button>
+        <?php endif; ?>
+
+        <?php if (donation_url($liveUser["id"], false) && $live["is_live"] !== 0) : ?>
+          <button type="button" class="btn btn-outline-warning" data-toggle="modal" data-target="#chModal"><i class="fas fa-donate"></i> 支援 (CH)</button>
+        <?php elseif (donation_url($liveUser["id"])) : ?>
+          <a class="btn btn-outline-warning" href="<?=donation_url($liveUser["id"])?>" target="_blank"><i class="fas fa-donate"></i> 支援</a>
+        <?php endif; ?>
+        <button type="button" class="btn btn-outline-info" onclick="live.share.share()"><i class="fas fa-share-square"></i> 共有</button>
+      </div>
+
       <?php include "../include/live/comment.php"; ?>
     </div>
   </div>

--- a/public/live.php
+++ b/public/live.php
@@ -124,7 +124,7 @@ $vote = loadVote($live["id"]);
       </div>
 
       <div class="alerts">
-        <div id="err_live" class="bg-warning text-dark"></div>
+        <div id="err_live" class="text-warning"></div>
         <div id="is_not_started" class="invisible">* この配信はまだ開始されていません。現在はあなたのみ視聴できます。<a href="<?=u("live_manage")?>">配信開始はこちらから</a></div>
       </div>
 

--- a/public/live.php
+++ b/public/live.php
@@ -112,9 +112,14 @@ $vote = loadVote($live["id"]);
         <iframe class="embed-responsive-item" src="<?=u("live_embed")?>?id=<?=$id?>&rtmp=<?=$slot["server"]?>" allowfullscreen id="iframe" allow="autoplay; fullscreen"></iframe>
       </div>
 
+      <input type="hidden" id="no_toot" value="<?=(!empty($my["misc"]["no_toot_default"]) ? "1" : "")?>">
       <div class="comment_block">
-        <div class="form-group">
+        <div class="input-group">
           <input class="form-control" id="toot" placeholder="Enterでコメント..." type="text">
+          <div class="input-group-append">
+            <button class="btn btn-<?=!empty($my["misc"]["no_toot_default"]) ? "" : "outline-"?>primary" id="comment_local_button" onclick="live.comment.toggleLocal()"
+            data-toggle="popover" data-trigger="hover" data-placement="bottom" title="ローカルで投稿" data-content="これを有効にすると、<?=isset($_SESSION["account_provider"]) ? $_SESSION["account_provider"] : "SNS"?>には投稿せずにコメントします。"><?=i("home")?></button>
+          </div>
         </div>
       </div>
 

--- a/public/login.php
+++ b/public/login.php
@@ -74,6 +74,7 @@ if (!$code) {
         $misc["avatar"] = $json_acct["avatar_static"];
         $misc["header"] = $json_acct["header_static"];
         $misc["user_url"] = $json_acct["url"];
+        $misc["no_toot_default"] = true;
         $misc = json_encode($misc);
         $stmt = $mysqli->prepare("INSERT INTO `users` (`id`, `name`, `acct`, `created_at`, `ip`, `misc`) VALUES (NULL, ?, ?, CURRENT_TIMESTAMP, ?, ?);");
         $stmt->bind_param('ssss', $name, $acct, $_SERVER["REMOTE_ADDR"], $misc);

--- a/public/settings.php
+++ b/public/settings.php
@@ -67,7 +67,7 @@ if ($_POST) {
         <div class="custom-control custom-checkbox">
           <input type="checkbox" class="custom-control-input" id="no_toot" name="no_toot_default" value="1" <?=(!empty($my["misc"]["no_toot_default"]) ? "checked" : "")?>>
           <label class="custom-control-label" for="no_toot">
-            「コメントのみ投稿」をデフォルトにする
+            「ローカルで投稿」をデフォルトにする
           </label>
         </div>
       </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14953122/54350720-472f5f80-4691-11e9-922f-a2f7cadbd04b.png)

- コメント欄
	- 1行にしてプレイヤー下に置いた
	- ローカル投稿をコメント欄右のボタンにした(ホバーすれば詳細な説明文が出る)
	- 文字数制限を書く代わりに `maxlength` を設定するようにした
- 配信ステータス(プッシュ待ち等のアラート)を上から下にして ~~`bg-warning text-dark` にした~~
- 配信情報とアイテム、支援、シェアボタンを右上に置いた
- ページレイアウトを `col-xl-9 col-lg-8` `col-xl-3 col-lg-4` にした
> **≥ 1200px** の時、 **8:4**
> **1200px > x ≥ 992px** の時、 **9:3**
> **< 992px** の時、スマホレイアウト
> (多分)