### PR TITLE
Use phpmig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     }
   ],
   "scripts": {
-    "fmt": "php-cs-fixer fix"
+    "fmt": "php-cs-fixer fix",
+    "phpmig": "phpmig"
   },
   "require": {
     "abraham/twitteroauth": "1.0.1",
@@ -20,6 +21,8 @@
     "league/flysystem-aws-s3-v3": "1.0.22",
     "intervention/image": "2.4.2",
     "php-ffmpeg/php-ffmpeg": "0.13.0",
-    "friendsofphp/php-cs-fixer": "2.14.2"
+    "friendsofphp/php-cs-fixer": "2.14.2",
+    "davedevelopment/phpmig": "^1.5",
+    "pimple/pimple": "^3.2"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "intervention/image": "2.4.2",
     "php-ffmpeg/php-ffmpeg": "0.13.0",
     "friendsofphp/php-cs-fixer": "2.14.2",
-    "davedevelopment/phpmig": "^1.5",
-    "pimple/pimple": "^3.2"
+    "davedevelopment/phpmig": "1.5",
+    "pimple/pimple": "3.2"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08ca7d31e7599a0042022356ffc6d73a",
+    "content-hash": "4b0a1b81252555389e4571d137997d67",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -366,6 +366,69 @@
                 "performance"
             ],
             "time": "2019-01-28T20:25:53+00:00"
+        },
+        {
+            "name": "davedevelopment/phpmig",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/davedevelopment/phpmig.git",
+                "reference": "0c6bb9277ce34f2ea3f1a58707bd11b8f8fffeed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/davedevelopment/phpmig/zipball/0c6bb9277ce34f2ea3f1a58707bd11b8f8fffeed",
+                "reference": "0c6bb9277ce34f2ea3f1a58707bd11b8f8fffeed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2",
+                "symfony/config": "^2.0||^3.0||^4.0",
+                "symfony/console": "^2.0||^3.0||^4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "*@dev",
+                "phpunit/phpunit": "3.*"
+            },
+            "suggest": {
+                "pimple/pimple": "Pimple allows to bootstrap phpmig really easily."
+            },
+            "bin": [
+                "bin/phpmig"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Phpmig": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                },
+                {
+                    "name": "David Nielsen",
+                    "email": "david@panmedia.co.nz"
+                }
+            ],
+            "description": "Simple migrations system for php",
+            "homepage": "http://github.com/davedevelopment/phpmig",
+            "keywords": [
+                "database migrations",
+                "migrations"
+            ],
+            "time": "2017-11-21T11:24:25+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -1438,6 +1501,105 @@
             "time": "2018-08-06T20:02:43+00:00"
         },
         {
+            "name": "pimple/pimple",
+            "version": "v3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/silexphp/Pimple.git",
+                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/9e403941ef9d65d20cba7d54e29fe906db42cf32",
+                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/container": "^1.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Pimple": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Pimple, a simple Dependency Injection Container",
+            "homepage": "http://pimple.sensiolabs.org",
+            "keywords": [
+                "container",
+                "dependency injection"
+            ],
+            "time": "2018-01-21T07:42:36+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -1573,6 +1735,69 @@
             ],
             "description": "A polyfill for getallheaders.",
             "time": "2016-02-11T07:05:27+00:00"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v4.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "0e745ead307d5dcd4e163e94a47ec04b1428943f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/0e745ead307d5dcd4e163e94a47ec04b1428943f",
+                "reference": "0e745ead307d5dcd4e163e94a47ec04b1428943f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/filesystem": "~3.4|~4.0",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/finder": "<3.4"
+            },
+            "require-dev": {
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/finder": "~3.4|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-04-01T14:03:25+00:00"
         },
         {
             "name": "symfony/console",
@@ -1976,7 +2201,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",

--- a/lib/live.php
+++ b/lib/live.php
@@ -49,7 +49,7 @@ function getLive($id) {
     $stmt->close();
     $mysqli->close();
     if (isset($row[0]["id"])) {
-        $row[0]["misc"] = json_decode($row[0]["misc"], true);
+        $row[0]["misc"] = empty($row[0]["misc"]) ? [] : json_decode($row[0]["misc"], true);
     }
 
     return isset($row[0]["id"]) ? $row[0] : false;

--- a/lib/user.php
+++ b/lib/user.php
@@ -27,7 +27,7 @@ function getUser($id, $mode = "id") {
 
     if (isset($row[0]["id"])) {
         $row[0]["misc"] = json_decode($row[0]["misc"], true);
-        $row[0]["ngwords"] = json_decode($row[0]["ngwords"], true);
+        $row[0]["ngwords"] = empty($row[0]["ngwords"]) ? [] : json_decode($row[0]["ngwords"], true);
     }
 
     if (!isset($userCache[$mode])) {

--- a/migrations/20190414000000_initDatabase.php
+++ b/migrations/20190414000000_initDatabase.php
@@ -190,13 +190,13 @@ class InitDatabase extends Migration {
         ALTER TABLE users_watching ADD user_id int(255) NULL;
 
         -- 2019-02-01
-        ALTER TABLE live ADD misc text DEFAULT '{}' NULL;
+        ALTER TABLE live ADD misc text NULL;
         ALTER TABLE live DROP is_sensitive;
         ALTER TABLE live ALTER COLUMN is_live SET DEFAULT 1;
         UPDATE `live` SET misc = '{"is_sensitive":false,"able_item":true,"able_comment":true}' WHERE misc = '{}';
 
         -- 2019-02-02
-        ALTER TABLE users ADD ngwords longtext DEFAULT '[]' NOT NULL;
+        ALTER TABLE users ADD ngwords longtext NULL;
         CREATE TABLE users_blocking
         (
           live_user_id int(255) NOT NULL,

--- a/migrations/20190414000000_initDatabase.php
+++ b/migrations/20190414000000_initDatabase.php
@@ -1,0 +1,302 @@
+<?php
+
+use Phpmig\Migration\Migration;
+
+class InitDatabase extends Migration {
+    /**
+     * Do the migration
+     */
+    public function up() {
+        $sql = <<< EOF
+        create table live
+        (
+          id                     int(100) auto_increment
+          primary key,
+          name                   varchar(100)       not null,
+          description            text               null,
+          user_id                int(100)           not null,
+          slot_id                int(10)            not null,
+          created_at             timestamp default current_timestamp()  not null,
+          ended_at             timestamp default current_timestamp()  not null,
+          is_live                int(2)             not null,
+          ip                     varchar(100)       not null,
+          token                  varchar(255)       not null,
+          privacy_mode           int(5)             null,
+          viewers_count          int(100) default 0 null,
+          viewers_max            int(100) default 0 null,
+          viewers_max_concurrent int(100) default 0 null
+        );
+
+        create table live_slot
+        (
+          id         int(100) auto_increment
+          primary key,
+          used       int(10)      not null,
+          max        int(10)      not null,
+          server     varchar(50)  not null,
+          server_ip  varchar(100) null,
+          is_testing int(2)       not null
+        );
+
+        create table users
+        (
+          id         int(10) auto_increment
+          primary key,
+          name       varchar(100)                            not null,
+          acct       varchar(100)                            not null,
+          created_at timestamp default current_timestamp() not null,
+          ip         varchar(100)                            not null,
+          isLive     int(2)                                  not null,
+          liveNow    int(100)                                not null,
+          misc       text                                    null
+        );
+
+        -- 2018-10-12 added
+        ALTER TABLE live ADD is_started int(2) DEFAULT 0 NOT NULL;
+
+        -- 2018-10-13 added
+        CREATE TABLE users_watching
+        (
+          ip varchar(255) NOT NULL primary key,
+          watch_id int(100) NOT NULL,
+          updated_at timestamp DEFAULT current_timestamp() NOT NULL
+        );
+
+        -- 2018-10-18 added
+        ALTER TABLE live ADD custom_hashtag varchar(255) NULL;
+
+        -- 2018-10-19 added
+        CREATE TABLE comment
+        (
+          id int(255) PRIMARY KEY NOT NULL AUTO_INCREMENT,
+          user_id varchar(255) NOT NULL,
+          content text NOT NULL,
+          created_at timestamp DEFAULT current_timestamp() NOT NULL,
+          live_id int(255) NOT NULL,
+          is_deleted int(3)
+        );
+
+        -- 2018-10-20 added
+        CREATE TABLE mastodon_auth
+        (
+          domain varchar(255) PRIMARY KEY NOT NULL,
+          client_id varchar(255) NOT NULL,
+          client_secret varchar(255) NOT NULL
+        );
+
+        -- 2018-12-25 added
+        -- auto-generated definition
+        create table prop_vote
+        (
+          id       int auto_increment,
+          live_id  int                not null,
+          title    varchar(255)       not null,
+          v1       varchar(255)       not null,
+          v2       varchar(255)       not null,
+          v3       varchar(255)       null,
+          v4       varchar(255)       null,
+          v1_count int(255) default 0 not null,
+          v2_count int(255) default 0 not null,
+          v3_count int(255) default 0 not null,
+          v4_count int(255) default 0 not null,
+          is_ended int(5) default 0   not null,
+          constraint prop_vote_id_uindex
+          unique (id)
+        );
+
+        create index prop_vote_live_id_index
+          on prop_vote (live_id);
+
+        alter table prop_vote
+          add primary key (id);
+
+        -- 2019-01-12 added
+        ALTER TABLE users ADD twitter_id varchar(100) NULL;
+        ALTER TABLE users CHANGE isLive is_broadcaster int(2) NOT NULL DEFAULT 0;
+        ALTER TABLE users CHANGE liveNow live_current_id int(100) NOT NULL DEFAULT 0;
+
+        -- 2019-01-13
+        ALTER TABLE live ADD comment_count int(100) DEFAULT 0 NOT NULL;
+        ALTER TABLE live
+          MODIFY COLUMN comment_count int(100) NOT NULL DEFAULT 0 AFTER viewers_max_concurrent;
+
+        -- 2019-01-16
+        ALTER TABLE users MODIFY name varchar(255) NOT NULL;
+
+        -- 2019/01/19
+        alter table users
+            add point_count int(255) default 0 not null;
+
+        create table point_log
+        (
+          id bigint auto_increment primary key,
+          created_at timestamp default current_timestamp not null,
+          user_id int(255) not null,
+          type varchar(100) not null,
+          data text null,
+          point int(255) default 0 not null
+        );
+
+        create unique index point_log_id_uindex
+          on point_log (id);
+
+        create index point_log_user_id_index
+          on point_log (user_id);
+
+        alter table users
+            add point_count_today_toot int(255) default 0 not null;
+
+        create table point_ticket
+        (
+          id varchar(100) not null,
+          point int(255) not null,
+          user_id int(255) not null,
+          created_at timestamp default current_timestamp not null,
+          comment text null,
+          used_by int(255) null
+        );
+
+        create unique index point_ticket_id_uindex
+          on point_ticket (id);
+
+        alter table point_ticket
+          add constraint point_ticket_pk
+            primary key (id);
+
+        create unique index users_id_uindex
+          on users (id);
+
+        create index users_point_count_today_toot_index
+          on users (point_count_today_toot);
+
+        -- 2019/01/23
+        alter table live
+          add point_count int(255) default 0 not null after comment_count;
+
+        -- 2019/01/25
+        ALTER TABLE users ADD opener_token varchar(255) NULL;
+        CREATE UNIQUE INDEX users_opener_token_uindex ON users (opener_token);
+
+        -- 2019/01/27
+        alter table live
+          add is_sensitive int(5) default 0 not null;
+
+        -- 2019-01-31
+        ALTER TABLE users_watching ADD watching_now int(5) DEFAULT 1 NOT NULL;
+        CREATE UNIQUE INDEX users_watching_ip_watch_id_uindex ON users_watching (ip, watch_id);
+        ALTER TABLE users_watching DROP PRIMARY KEY;
+
+        -- 2019-01-31
+        ALTER TABLE users_watching ADD user_id int(255) NULL;
+
+        -- 2019-02-01
+        ALTER TABLE live ADD misc text DEFAULT '{}' NULL;
+        ALTER TABLE live DROP is_sensitive;
+        ALTER TABLE live ALTER COLUMN is_live SET DEFAULT 1;
+        UPDATE `live` SET misc = '{"is_sensitive":false,"able_item":true,"able_comment":true}' WHERE misc = '{}';
+
+        -- 2019-02-02
+        ALTER TABLE users ADD ngwords longtext DEFAULT '[]' NOT NULL;
+        CREATE TABLE users_blocking
+        (
+          live_user_id int(255) NOT NULL,
+          target_user_id int(255) NOT NULL,
+          created_by int(255) NOT NULL,
+          misc text,
+          created_at timestamp DEFAULT current_timestamp() NOT NULL,
+          is_permanent int(5) DEFAULT 0 NOT NULL,
+          is_blocking_watch int(5) DEFAULT 0 NOT NULL
+        );
+        CREATE UNIQUE INDEX users_blocking_live_user_id_target_user_id_uindex ON users_blocking (live_user_id, target_user_id);
+        CREATE INDEX users_blocking_live_user_id_index ON users_blocking (live_user_id);
+
+        -- 2019-02-06
+        create table comment_delete
+        (
+          id varchar(255) not null,
+          live_id int(255) not null,
+          created_at timestamp default current_timestamp() not null,
+          created_by int(255) not null
+        );
+
+        create unique index comment_delete_id_uindex
+          on comment_delete (id);
+
+        create index comment_delete_live_id_index
+          on comment_delete (live_id);
+
+        alter table comment_delete
+          add constraint comment_delete_pk
+            primary key (id);
+
+        -- 2019-02-08
+        alter table users change is_broadcaster broadcaster_id varchar(255) null;
+
+        UPDATE `users` SET broadcaster_id = acct WHERE broadcaster_id = '1';
+        UPDATE `users` SET broadcaster_id = null WHERE broadcaster_id = '0';
+        create unique index users_broadcaster_id_uindex
+          on users (broadcaster_id);
+
+        -- 2019/02/15
+        create table donate
+        (
+          id bigint auto_increment,
+          live_id int(255) not null,
+          user_id int(255) not null,
+          amount int(255) not null,
+          currency varchar(10) not null,
+          created_at timestamp default current_timestamp() not null,
+          ended_at timestamp not null,
+          color varchar(100) not null,
+          primary key (id)
+        );
+
+        create unique index donate_id_uindex
+          on donate (id);
+
+        -- 2019/02/16
+        alter table donate modify amount float not null;
+
+        -- 2019/02/19
+        alter table users
+          add donation_desc text null;
+
+        -- 2019/02/25
+        alter table users_blocking add target_user_acct varchar(255) not null after live_user_id;
+        alter table users_blocking add constraint users_blocking_live_user_id_target_user_acct_uindex unique (live_user_id, target_user_acct);
+
+        drop index users_blocking_live_user_id_target_user_id_uindex on users_blocking;
+        alter table users_blocking drop column target_user_id;
+
+        -- 2019/03/09
+        alter table users_watching
+            add created_at timestamp default current_timestamp not null;
+
+        -- 2019/03/11
+        create table items
+        (
+            id bigint auto_increment,
+            type varchar(10) not null,
+            user_id int(255) not null,
+            name varchar(255) not null,
+            point int(255) default 0 not null,
+            file_name varchar(255) not null,
+            created_at timestamp default current_timestamp() not null,
+            able_item int(2) null,
+            able_comment int(2) null,
+            primary key (id)
+        );
+
+        create unique index items_id_uindex
+            on items (id);
+
+        create index items_user_id_type_index
+            on items (user_id, type);
+
+        create unique index items_type_user_id_name_uindex
+          on items (type, user_id, name);
+EOF;
+        $container = $this->getContainer();
+        $container['db']->query($sql);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "fmt:json": "prettier --write '**/*.json'",
     "fmt:css": "stylelint --fix **/*.scss && prettier --write '**/*.scss'",
     "fmt:js": "prettier --write '**/*.js'",
+    "fmt:php": "composer fmt",
     "fmt": "npm-run-all fmt:* -s",
     "check:deps": "node ./scripts/check-deps.js",
     "check:fmt:md": "prettier --check '**/*.md'",
@@ -25,7 +26,8 @@
     "check:fmt:js": "prettier --check '**/*.js'",
     "check:fmt": "npm-run-all check:fmt:* -s",
     "watch": "webpack --watch",
-    "build": "webpack"
+    "build": "webpack",
+    "db:migrate": "composer phpmig migrate"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.8.1",

--- a/phpmig.php
+++ b/phpmig.php
@@ -1,0 +1,29 @@
+<?php
+use Phpmig\Adapter;
+use Pimple\Container;
+
+$container = new Container();
+
+$container['db'] = function () {
+    require_once __DIR__ . '/config.php';
+
+    $mysql = "mysql:dbname={$env['database']['db']};host={$env['database']['host']};port={$env['database']['port']}";
+    $dbh = new PDO($mysql, $env['database']['user'], $env['database']['pass']);
+    $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    return $dbh;
+};
+
+$container['phpmig.adapter'] = function ($c) {
+    return new Adapter\PDO\Sql($c['db'], 'migrations');
+};
+
+$container['phpmig.migrations_path'] = __DIR__ . DIRECTORY_SEPARATOR . 'migrations';
+
+// You can also provide an array of migration files
+// $container['phpmig.migrations'] = array_merge(
+//     glob('migrations_1/*.php'),
+//     glob('migrations_2/*.php')
+// );
+
+return $container;

--- a/support/sql/knzklive.sql
+++ b/support/sql/knzklive.sql
@@ -211,13 +211,13 @@ ALTER TABLE users_watching DROP PRIMARY KEY;
 ALTER TABLE users_watching ADD user_id int(255) NULL;
 
 -- 2019-02-01
-ALTER TABLE live ADD misc text DEFAULT '{}' NULL;
+ALTER TABLE live ADD misc text NULL;
 ALTER TABLE live DROP is_sensitive;
 ALTER TABLE live ALTER COLUMN is_live SET DEFAULT 1;
 UPDATE `live` SET misc = '{"is_sensitive":false,"able_item":true,"able_comment":true}' WHERE misc = '{}';
 
 -- 2019-02-02
-ALTER TABLE users ADD ngwords longtext DEFAULT '[]' NOT NULL;
+ALTER TABLE users ADD ngwords longtext NULL;
 CREATE TABLE users_blocking
 (
   live_user_id int(255) NOT NULL,
@@ -324,7 +324,8 @@ create table migrations (
   version varchar(255) not null
 );
 
-INSERT INTO knzklive.migrations (version) VALUES ('20190414000000');
+INSERT INTO migrations (version) VALUES ('20190414000000');
+COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;

--- a/support/sql/knzklive.sql
+++ b/support/sql/knzklive.sql
@@ -1,3 +1,9 @@
+-- ======================================
+-- THIS FILE IS OUTDATED!
+-- Please **apply the SQL of 2019/04/14** and use 'yarn db:migrate' command.
+-- ======================================
+
+
 -- phpMyAdmin SQL Dump
 -- version 4.8.0.1
 -- https://www.phpmyadmin.net/
@@ -312,6 +318,7 @@ create unique index items_type_user_id_name_uindex
   on items (type, user_id, name);
 
 -- 2019/04/14
+-- Use phpmig migration
 
 create table migrations (
   version varchar(255) not null

--- a/support/sql/knzklive.sql
+++ b/support/sql/knzklive.sql
@@ -311,6 +311,14 @@ create index items_user_id_type_index
 create unique index items_type_user_id_name_uindex
   on items (type, user_id, name);
 
+-- 2019/04/14
+
+create table migrations (
+  version varchar(255) not null
+);
+
+INSERT INTO knzklive.migrations (version) VALUES ('20190414000000');
+
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;


### PR DESCRIPTION
sqlファイルで管理していたマイグレーションをphpmigを使用するように変更します。

# 1. これからDBを1から構築する場合
```sql
create database knzklive;
```
を適用した上で、
```bash
yarn db:migrate
```
コマンドを使用すればセットアップできます。

# 2. 今まで手動で管理していたDBをphpmig管理にする場合
```sql
create table migrations (
  version varchar(255) not null
);

INSERT INTO knzklive.migrations (version) VALUES ('20190414000000');
```
を適用した上で、
```bash
yarn db:migrate
```
を実行してください。

> `20190414000000` のマイグレーションファイルが今までのknzklive.sqlをまとめた物なのでこれを強制的にスキップさせます。

今後は `yarn db:migrate` のみでマイグレーションできるようになると思います。